### PR TITLE
Add hexadecimal printout of instruction in disassembler

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -49,7 +49,7 @@ fn main() {
 
                 let decoded = Instruction::new(instruction);
 
-                println!("{:x}:\t{:#?}", address, decoded);
+                println!("{:x}:\t{:x}\t{:#?}", address, instruction, decoded);
             }
         }
     }


### PR DESCRIPTION
Addresses and solves issue #1.