### PR TITLE
Fix Display Output on Disassembler

### DIFF
--- a/src/bin/disassembler.rs
+++ b/src/bin/disassembler.rs
@@ -45,10 +45,10 @@ fn main() {
                 let decoded = Instruction::new(instruction);
 
                 if show_counter || show_all {
-                    print!("{:>8}", address);
+                    print!("{:>8} ", address);
                 }
                 if show_hex || show_all {
-                    print!("{:>8}", instruction);
+                    print!("{:>10} ", instruction);
                 }
                 if show_ascii || show_all {
                     print!(

--- a/src/riscv/decoder.rs
+++ b/src/riscv/decoder.rs
@@ -307,7 +307,7 @@ impl Display for Instruction {
         match self.instr.instr_type {
             RVT::R => write!(
                 f,
-                "{:<8.3}{},{},{}",
+                "{:<8.6}{},{},{}",
                 self.instr,
                 get_register_label(self.rd.unwrap()),
                 get_register_label(self.rs1.unwrap()),
@@ -315,7 +315,7 @@ impl Display for Instruction {
             ),
             RVT::I if self.instr.is_load() => write!(
                 f,
-                "{:<8.3}{},{}({})",
+                "{:<8.6}{},{}({})",
                 self.instr,
                 get_register_label(self.rd.unwrap()),
                 self.imm.unwrap(),
@@ -323,7 +323,7 @@ impl Display for Instruction {
             ),
             RVT::I => write!(
                 f,
-                "{:<8.3}{},{},{}",
+                "{:<8.6}{},{},{}",
                 self.instr,
                 get_register_label(self.rd.unwrap()),
                 get_register_label(self.rs1.unwrap()),
@@ -335,7 +335,7 @@ impl Display for Instruction {
             ),
             RVT::S => write!(
                 f,
-                "{:<8.3}{}, {}({})",
+                "{:<8.6}{}, {}({})",
                 self.instr,
                 get_register_label(self.rs2.unwrap()),
                 self.imm.unwrap(),
@@ -343,7 +343,7 @@ impl Display for Instruction {
             ),
             RVT::B => write!(
                 f,
-                "{:<8.3}{},{},{}",
+                "{:<8.6}{},{},{}",
                 self.instr,
                 get_register_label(self.rs1.unwrap()),
                 get_register_label(self.rs2.unwrap()),
@@ -351,14 +351,14 @@ impl Display for Instruction {
             ),
             RVT::U => write!(
                 f,
-                "{:<8.3}{},{}",
+                "{:<8.6}{},{}",
                 self.instr,
                 get_register_label(self.rd.unwrap()),
                 self.imm.unwrap()
             ),
             RVT::J => write!(
                 f,
-                "{:<8.3}{},{}",
+                "{:<8.6}{},{}",
                 self.instr,
                 get_register_label(self.rd.unwrap()),
                 self.imm.unwrap()


### PR DESCRIPTION
Fixed  2 things

1-aligned 32-bit instructions
2-Output of AssemblyCode was with only 3 characters

Closes #26 